### PR TITLE
Issue 6

### DIFF
--- a/dev_src/packages/runtime/meta/installscript.qs
+++ b/dev_src/packages/runtime/meta/installscript.qs
@@ -10,11 +10,11 @@ Component.prototype.createOperations = function()
 
 	if (systemInfo.productType === "windows") {
 		install_runtime("2013", "12.0", 21005); // Note: 21005 displays as 30501
-		install_runtime("2015", "14.0", 23026);
+		install_runtime("2017", "14.0", 26706);
 
 	}
 	delete_runtime("2013");
-	delete_runtime("2015");
+	delete_runtime("2017");
 }
 
 function install_runtime(vs_ver, major_subkey, build)

--- a/dev_src/packages/runtime/meta/installscript.qs
+++ b/dev_src/packages/runtime/meta/installscript.qs
@@ -9,9 +9,49 @@ Component.prototype.createOperations = function()
 	component.createOperations();
 
 	if (systemInfo.productType === "windows") {
-		component.addOperation("Execute", "@TargetDir@/vc2013_vcredist_x64.exe", "/q");
-		component.addOperation("Execute", "@TargetDir@/vc2017_vcredist_x64.exe", "/q");
-		component.addOperation("Delete", "@TargetDir@/vc2013_vcredist_x64.exe");
-		component.addOperation("Delete", "@TargetDir@/vc2017_vcredist_x64.exe");
+		install_runtime("2013", "12.0", 21005); // Note: 21005 displays as 30501
+		install_runtime("2015", "14.0", 23026);
+
 	}
+	delete_runtime("2013");
+	delete_runtime("2015");
+}
+
+function install_runtime(vs_ver, major_subkey, build)
+{
+	var executable = "vc" + vs_ver + "_vcredist_x64.exe";  // ie vc2013_vcredist_x64.exe
+	var runtime = "Microsoft Visual C++ " + vs_ver + " Runtime Bld " + build.toString();
+	var key = "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\" + major_subkey + "\\VC\\Runtimes\\x64"
+
+	// check if major version is installed
+	var installed = installer.execute("reg", new Array("QUERY", key, "/v", "Installed"))[0];
+	if (installed) {
+		// check build number
+		var bld = installer.execute("reg", new Array("QUERY", key, "/v", "Bld"))[0];
+		var elements = bld.split(" ");
+		bld = parseInt(elements[elements.length-1])
+		var year_string = vs_ver
+		if (year_string === "2015" || year_string === "2017") {
+			// Note: both 2015 and 2017 use the 14.0 major subkey
+			year_string = "2015/2017"
+		}
+		console.log("Found Microsoft Visual C++ " + year_string + " Runtime Bld " + bld.toString());
+		if (bld < build) {
+			console.log("Installing " + runtime + ": " + executable + " /quiet /norestart");
+			component.addOperation("Execute", "@TargetDir@/" + executable, "/quiet", "/norestart");
+		}
+		else {
+			console.log("No need to install " + runtime);
+		}
+	}
+	else {
+		console.log("Installing " + runtime + ": " + executable + " /quiet");
+		component.addOperation("Execute", "@TargetDir@/" + executable, "/quiet");
+	}
+}
+
+function delete_runtime(vs_ver)
+{
+	var executable = "vc" + vs_ver + "_vcredist_x64.exe";  // ie vc2013_vcredist_x64.exe
+	component.addOperation("Delete", "@TargetDir@/" + executable);
 }

--- a/prod_src/packages/runtime/meta/installscript.qs
+++ b/prod_src/packages/runtime/meta/installscript.qs
@@ -10,11 +10,11 @@ Component.prototype.createOperations = function()
 
 	if (systemInfo.productType === "windows") {
 		install_runtime("2013", "12.0", 21005); // Note: 21005 displays as 30501
-		install_runtime("2015", "14.0", 23026);
+		install_runtime("2017", "14.0", 26706);
 
 	}
 	delete_runtime("2013");
-	delete_runtime("2015");
+	delete_runtime("2017");
 }
 
 function install_runtime(vs_ver, major_subkey, build)

--- a/prod_src/packages/runtime/meta/installscript.qs
+++ b/prod_src/packages/runtime/meta/installscript.qs
@@ -9,9 +9,49 @@ Component.prototype.createOperations = function()
 	component.createOperations();
 
 	if (systemInfo.productType === "windows") {
-		component.addOperation("Execute", "@TargetDir@/vc2013_vcredist_x64.exe", "/q");
-		component.addOperation("Execute", "@TargetDir@/vc2017_vcredist_x64.exe", "/q");
-		component.addOperation("Delete", "@TargetDir@/vc2013_vcredist_x64.exe");
-		component.addOperation("Delete", "@TargetDir@/vc2017_vcredist_x64.exe");
+		install_runtime("2013", "12.0", 21005); // Note: 21005 displays as 30501
+		install_runtime("2015", "14.0", 23026);
+
 	}
+	delete_runtime("2013");
+	delete_runtime("2015");
+}
+
+function install_runtime(vs_ver, major_subkey, build)
+{
+	var executable = "vc" + vs_ver + "_vcredist_x64.exe";  // ie vc2013_vcredist_x64.exe
+	var runtime = "Microsoft Visual C++ " + vs_ver + " Runtime Bld " + build.toString();
+	var key = "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\" + major_subkey + "\\VC\\Runtimes\\x64"
+
+	// check if major version is installed
+	var installed = installer.execute("reg", new Array("QUERY", key, "/v", "Installed"))[0];
+	if (installed) {
+		// check build number
+		var bld = installer.execute("reg", new Array("QUERY", key, "/v", "Bld"))[0];
+		var elements = bld.split(" ");
+		bld = parseInt(elements[elements.length-1])
+		var year_string = vs_ver
+		if (year_string === "2015" || year_string === "2017") {
+			// Note: both 2015 and 2017 use the 14.0 major subkey
+			year_string = "2015/2017"
+		}
+		console.log("Found Microsoft Visual C++ " + year_string + " Runtime Bld " + bld.toString());
+		if (bld < build) {
+			console.log("Installing " + runtime + ": " + executable + " /quiet /norestart");
+			component.addOperation("Execute", "@TargetDir@/" + executable, "/quiet", "/norestart");
+		}
+		else {
+			console.log("No need to install " + runtime);
+		}
+	}
+	else {
+		console.log("Installing " + runtime + ": " + executable + " /quiet");
+		component.addOperation("Execute", "@TargetDir@/" + executable, "/quiet");
+	}
+}
+
+function delete_runtime(vs_ver)
+{
+	var executable = "vc" + vs_ver + "_vcredist_x64.exe";  // ie vc2013_vcredist_x64.exe
+	component.addOperation("Delete", "@TargetDir@/" + executable);
 }

--- a/yasu_src/packages/runtime/meta/installscript.qs
+++ b/yasu_src/packages/runtime/meta/installscript.qs
@@ -9,9 +9,49 @@ Component.prototype.createOperations = function()
 	component.createOperations();
 
 	if (systemInfo.productType === "windows") {
-		component.addOperation("Execute", "@TargetDir@/vc2013_vcredist_x64.exe", "/q");
-		component.addOperation("Execute", "@TargetDir@/vc2015_vcredist_x64.exe", "/q");
-		component.addOperation("Delete", "@TargetDir@/vc2013_vcredist_x64.exe");
-		component.addOperation("Delete", "@TargetDir@/vc2015_vcredist_x64.exe");
+		install_runtime("2013", "12.0", 21005); // Note: 21005 displays as 30501
+		install_runtime("2015", "14.0", 23026);
+
 	}
+	delete_runtime("2013");
+	delete_runtime("2015");
+}
+
+function install_runtime(vs_ver, major_subkey, build)
+{
+	var executable = "vc" + vs_ver + "_vcredist_x64.exe";  // ie vc2013_vcredist_x64.exe
+	var runtime = "Microsoft Visual C++ " + vs_ver + " Runtime Bld " + build.toString();
+	var key = "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\" + major_subkey + "\\VC\\Runtimes\\x64"
+
+	// check if major version is installed
+	var installed = installer.execute("reg", new Array("QUERY", key, "/v", "Installed"))[0];
+	if (installed) {
+		// check build number
+		var bld = installer.execute("reg", new Array("QUERY", key, "/v", "Bld"))[0];
+		var elements = bld.split(" ");
+		bld = parseInt(elements[elements.length-1])
+		var year_string = vs_ver
+		if (year_string === "2015" || year_string === "2017") {
+			// Note: both 2015 and 2017 use the 14.0 major subkey
+			year_string = "2015/2017"
+		}
+		console.log("Found Microsoft Visual C++ " + year_string + " Runtime Bld " + bld.toString());
+		if (bld < build) {
+			console.log("Installing " + runtime + ": " + executable + " /quiet /norestart");
+			component.addOperation("Execute", "@TargetDir@/" + executable, "/quiet", "/norestart");
+		}
+		else {
+			console.log("No need to install " + runtime);
+		}
+	}
+	else {
+		console.log("Installing " + runtime + ": " + executable + " /quiet");
+		component.addOperation("Execute", "@TargetDir@/" + executable, "/quiet");
+	}
+}
+
+function delete_runtime(vs_ver)
+{
+	var executable = "vc" + vs_ver + "_vcredist_x64.exe";  // ie vc2013_vcredist_x64.exe
+	component.addOperation("Delete", "@TargetDir@/" + executable);
 }

--- a/yasu_src/packages/runtime/meta/installscript.qs
+++ b/yasu_src/packages/runtime/meta/installscript.qs
@@ -10,11 +10,11 @@ Component.prototype.createOperations = function()
 
 	if (systemInfo.productType === "windows") {
 		install_runtime("2013", "12.0", 21005); // Note: 21005 displays as 30501
-		install_runtime("2015", "14.0", 23026);
+		install_runtime("2017", "14.0", 26706);
 
 	}
 	delete_runtime("2013");
-	delete_runtime("2015");
+	delete_runtime("2017");
 }
 
 function install_runtime(vs_ver, major_subkey, build)


### PR DESCRIPTION
Hi Keisuke,

This should fix the reboot problem.  I also modified so that it only installs runtimes if needed (if it doesn't exist or requires a newer version).

Installing the runtimes returns the value 3010 if a reboot is required.  I wasn't able to find how to inform the qt installer framework that a reboot was required.  If you know how to do this we can add it.  I don't think it should be a problem since it should just use the old version until the machine is rebooted.

Thanks,
Scott
