### PR TITLE
Close #15

### DIFF
--- a/dev_src/qt_ifw_path.template.py
+++ b/dev_src/qt_ifw_path.template.py
@@ -1,3 +1,3 @@
 # Path where Qt Installer Framework is installed
 
-QT_IFW_PATH = 'C:\\Qt\\Tools\\QtInstallerFramework\\2.0'
+QT_IFW_PATH = 'C:\\Qt\\Tools\\QtInstallerFramework\\3.2'

--- a/qt_ifw_path.template.py
+++ b/qt_ifw_path.template.py
@@ -1,3 +1,3 @@
 # Path where Qt Installer Framework is installed
 
-QT_IFW_PATH = 'C:\\Qt\\Tools\\QtInstallerFramework\\2.0'
+QT_IFW_PATH = 'C:\\Qt\\Tools\\QtInstallerFramework\\3.2'


### PR DESCRIPTION
I've made sure the followings:
* Offline / online installers can be built without modifying files in dev_src and prod_src folders.
* iRIC Maintainance tool can download and install binary files built with Qt Installer Framework 2.0. It has backward compatibility.
